### PR TITLE
removed engines field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,5 @@
   "devDependencies" : {
     "mocha" : "*",
     "sinon" : "*"
-	},
-  "engines": {
-    "node": "0.10.x",
-    "npm": "1.3.x"
   }
 }


### PR DESCRIPTION
Just a minor issue, but although this package works fine with newer versions of node and npm, it triggers a warning because of the engines declaration in package.json:

e.g.: npm WARN engine imei@0.0.1: wanted: {"node":"0.10.x","npm":"1.3.x"} (current: {"node":"4.2.2","npm":"2.14.7"})
