### PR TITLE
Allow parameters to be numbers or strings (since IMEIs are numbers).

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,20 +3,22 @@ var checkdigit = require('checkdigit');
 var imei = {};
 
 imei.isValid = function(i) {
-  return i.length === 15 && checkdigit.mod10.isValid(i);
+  var str = i.toString();
+  return str.length === 15 && checkdigit.mod10.isValid(str);
 };
 
 imei.next = function(prev, done) {
+  var prevStr = prev.toString();
   if(!imei.isValid(prev)) {
     return done('invalid imei');
   }
 
-  var serialNumber = prev.substr(8, 6);
+  var serialNumber = prevStr.substr(8, 6);
   if(serialNumber === '999999') {
     return done('no more IMEIs in TAC range');
   }
 
-  var withoutLuhn = prev.substr(0, 14);
+  var withoutLuhn = prevStr.substr(0, 14);
   var nextWithoutLuhn = parseInt(withoutLuhn, 10) + 1;
   var next = checkdigit.mod10.apply(nextWithoutLuhn.toString());
 

--- a/test/imei_test.js
+++ b/test/imei_test.js
@@ -5,6 +5,7 @@ describe('imei', function() {
   describe('isValid', function() {
     it('should return true for valid imeis', function() {
       assert(imei.isValid('352099001761481'));
+      assert(imei.isValid(352099001761481));
     });
 
     it('should return false for valid imeis', function() {
@@ -14,8 +15,15 @@ describe('imei', function() {
   });
 
   describe('next', function() {
-    it('should return next one for valid imei', function(done) {
+    it('should return next one for valid imei (string)', function(done) {
       imei.next('352099001761481', function(e, next) {
+        assert.equal(next, '352099001761499');
+        return done(e);
+      });
+    });
+
+    it('should return next one for valid imei (number)', function(done) {
+      imei.next(352099001761481, function(e, next) {
         assert.equal(next, '352099001761499');
         return done(e);
       });
@@ -27,7 +35,7 @@ describe('imei', function() {
         return done();
       });
     });
-    
+
     it('should return error when reaching the end of the TAC range', function(done) {
       imei.next('352099009999992', function(e, next) {
         assert.equal(e, 'no more IMEIs in TAC range');


### PR DESCRIPTION
Since IMEIs are numbers, it makes sense to accept a number as the input to the `isValid` and `next` methods.
